### PR TITLE
Optionen um Code vorabzuladen

### DIFF
--- a/codeworld-server/codeworld-server.cabal
+++ b/codeworld-server/codeworld-server.cabal
@@ -36,6 +36,7 @@ Executable codeworld-server
     cryptonite,
     data-default,
     directory,
+    extra,
     fast-logger,
     filelock,
     filepath,

--- a/web/env.html
+++ b/web/env.html
@@ -38,6 +38,9 @@
       rel="stylesheet"
       href="mirrored/ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"
     />
+    <script>
+      window.preloadCode = `/*CODE_TO_BE_LOADED_BY_DEFAULT*/`;
+    </script>
   </head>
 
   <body>

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -361,6 +361,8 @@ picture = ...
       );
     }
   }
+
+  if(window.preloadCode && window.buildMode === 'haskell')setCode(window.preloadCode);
 }
 
 function initCodeworld() {

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -322,6 +322,45 @@ program = drawingOf(picture & coordinatePlane)
 picture = ...
 `);
   }
+
+  const currentUrl = new URL(window.location);
+  const searchParams = currentUrl.searchParams;
+  const codeSrc = searchParams.get("loadSrc");
+  if(codeSrc) {
+    const fetchController = new AbortController();
+    sweetAlert({
+      title: Alert.title('Loading code'),
+      text: 'The code is being fetched.  Please wait...',
+      onOpen: () => {
+        sweetAlert.showLoading();
+        sweetAlert.getCancelButton().disabled = false;
+      },
+      showConfirmButton: false,
+      showCancelButton: true,
+      showCloseButton: false,
+      allowOutsideClick: false,
+      allowEscapeKey: false,
+      allowEnterKey: false,
+    }).then(() => {
+      fetchController.abort();
+    });
+    try {
+      const response = await fetch(codeSrc, {
+        signal: fetchController.signal,
+      });
+      const code = await response.text();
+      setCode(code);
+      sweetAlert.close();
+      searchParams.delete("loadSrc");
+      window.history.replaceState(window.history.state, "", currentUrl.toString());
+    } catch (error) {
+      sweetAlert(
+        'Oops!',
+        'Could not load the code from source. Please try again.',
+        'error'
+      );
+    }
+  }
 }
 
 function initCodeworld() {


### PR DESCRIPTION
Fügt zwei Optionen hinzu, um Code aus einer Quelle zu laden:

1. Vorabladen von Code via searchParameter


Es ist nun möglich über den searchParameter `loadSrc` eine URL anzugeben, von der Code vorab zu laden ist. Wichtig ist hierbei, dass die Response über die entsprechenden CORS Header verfügt. Andernfalls ist ein Vorabladen nicht möglich. Die Idee ist hier z. B. ein Template als Gist hochzuladen und dies dann mit dem seachParameter vorab zuladen. Das könnte dann so aussehen:
```
https://autotool.fmi.uni-due.de/haskell?loadSrc=https://gist.github.com/...
```

2. Vorabladen von Code via POST Request

Es ist jetzt möglich, Code über eine POST Request an `/haskell` vorabzuladen. Die Payload (als `multipart/form-data` encoded) muss hierbei über das Feld `source` verfügen. Vorgesehen ist dafür die Nutzung eines `<form>` Elements, sodass der Nutzer am Ende auch auf `/haskell` landet (eine alleinstehende Request würde auch keinen Sinn ergeben). Dies erlaubt es z.B. eine Abgabe aus Autotool direkt zu CodeWorld zu posten.

Der Hintergrund für diese Änderung ist hier zu finden: [autotool-dev#6](https://git.uni-due.de/fmi/autotool-dev/-/issues/6)