### PR TITLE
Better error message when type from `codeworld-base` is hidden

### DIFF
--- a/codeworld-error-sanitizer/src/ErrorSanitizer.hs
+++ b/codeworld-error-sanitizer/src/ErrorSanitizer.hs
@@ -41,6 +41,8 @@ rewriteStages =
     ),
     ("is applied to too few arguments", "is missing arguments"),
     ("is applied to too many arguments", "is a value, but a function is needed here."),
+    ( "Couldn't match expected type codeworld-base-[\\.0-9]*:([A-Za-z]*\\.)*([A-Za-z]*)",
+      "Couldn't match expected type \\2"),
     ( "Couldn't match expected type Text\\s*with actual type GHC.Types.Char",
       "Text requires double quotes, rather than single."
     ),


### PR DESCRIPTION
The error message will now look like this:
```
Couldn't match expected type Number with actual type Picture
```

Closes #21 