### PR TITLE
Update Deployment

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -23,25 +23,7 @@ docker buildx build --load --cache-from=type=local,src=${CACHE}/dist ${CACHE_TO}
 
 docker create --name codeworld codeworld:fmi
 
-docker cp codeworld:/opt/codeworld/codeworld.keter codeworld.keter
+docker cp codeworld:/opt/codeworld/codeworld.keter codeworld.tar
 
 docker rm codeworld
 
-TMPDIR=$(mktemp -d)
-ARCHIVEPATH="$(pwd)/codeworld.keter"
-
-# Create bundle
-
-cd $TMPDIR
-
-echo "Tempdir: $TMPDIR"
-
-tar xf "$ARCHIVEPATH"
-
-cd -
-
-rm -rf codeworld.keter
-
-tar czf codeworld.keter config/keter.yaml -C $TMPDIR .cabal/ .ghcjs/ base.sh run.sh build/ codeworld-base/ web/
-
-rm -rf $TMPDIR

--- a/publish.sh
+++ b/publish.sh
@@ -18,6 +18,16 @@ then
   REMOTE_DIR=${TARGET_FOLDER}${TIME}
 fi
 
+cp codeworld.tar codeworld-tmp.tar
+
+tar -rf codeworld-tmp.tar config/keter.yaml
+
+gzip codeworld-tmp.tar
+
+rm -f codeworld.keter
+mv codeworld-tmp.tar.gz codeworld.keter
+
+
 ssh ${JUMP_HOST:+-J} ${JUMP_HOST:+"${JUMP_HOST}"}\
   -p "${PORT}" "${SSH_USER}@${SERVER}" -C "mkdir -p ${REMOTE_DIR}"
 


### PR DESCRIPTION
Ein paar Bemerkungen:
- Die `codeworld.tar` aus dem Image enthält noch keine Keter-Config und ist nicht komprimiert
- Um Probleme zu vermeiden, wird die `codeworld.tar` temporär geklont
- Dann wird die `config/keter.yaml` hinzugefügt und das Archiv komprimiert
- Ergebnis: `codeworld.tar` (unverändert), `codeworld.keter` (fertiges Keter-Archiv)