### PR TITLE
Code Escaping (via POST) vor dem Laden entfernen

### DIFF
--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -365,7 +365,10 @@ picture = ...
     }
   }
 
-  if(window.preloadCode && window.buildMode === 'haskell')setCode(window.preloadCode);
+  if(window.preloadCode && window.buildMode === 'haskell'){
+    const codeToLoad = new DOMParser().parseFromString(window.preloadCode, 'text/html').documentElement.textContent;
+    setCode(codeToLoad);
+  };
 }
 
 function initCodeworld() {


### PR DESCRIPTION
Der Code, der mittels POST-Request geladen werden soll, könnte potenziell escaped sein. 
Etwa so: 
```
putStrLn :: String -&gt; IO ()
...
```
Aktuell wird dieser, so wie er ist, in den Editor geladen und führt dementsprechend zu Fehlern.

Dieser Pull Request ändert dies. Der Code wird ab sofort zunächst unescaped.