### PR TITLE
Hash nach dem Laden von lokalem Code nicht entfernen

### DIFF
--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -1970,9 +1970,6 @@ function run(hash, dhash, msg, error, generation) {
   if (hash) {
     window.location.hash = `#${hash}`;
     // document.getElementById('shareButton').style.display = '';
-  } else {
-    window.location.hash = '';
-    // document.getElementById('shareButton').style.display = 'none';
   }
 
   if (dhash) {


### PR DESCRIPTION
Aktuell wird der Hash nach dem Laden des lokal gespeicherten Codes aus der URL entfernt. Um an diesen wieder zu gelangen, müsste man dann nochmal auf `Run` drücken.

Der Hash würde ab sofort nicht mehr entfernt werden.