### PR TITLE
Remove extraneous dependencies

### DIFF
--- a/web/blocks.html
+++ b/web/blocks.html
@@ -143,7 +143,6 @@
       </div>
     </div>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
     <script
       type="text/javascript"
       src="js/details-element-polyfill.js"

--- a/web/doc.html
+++ b/web/doc.html
@@ -18,7 +18,6 @@
 
 <html>
   <head>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
     <script
       src="mirrored/code.jquery.com/jquery-1.12.4.min.js"
       integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="

--- a/web/env.html
+++ b/web/env.html
@@ -19,7 +19,6 @@
 <html>
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type" />
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
     <title>CodeWorld</title>
     <link rel="stylesheet" href="css/codemirror.css" />
     <link rel="stylesheet" href="css/ambiance.css" />
@@ -134,7 +133,6 @@
       type="text/javascript"
       src="mirrored/cdnjs.cloudflare.com/ajax/libs/jqtree/1.4.10/tree.jquery.js"
     ></script>
-    <script type="text/javascript" src="https://wurfl.io/wurfl.js"></script>
     <script
       type="text/javascript"
       src="js/codemirror-compressed.js"

--- a/web/gallery.html
+++ b/web/gallery.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
     <title>CodeWorld Gallery</title>
     <script src="mirrored/code.jquery.com/jquery-1.12.4.js"></script>
     <link rel="stylesheet" href="css/gallery.css" />

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -388,7 +388,7 @@ function initCodeworld() {
     lineNumbers: true,
     autofocus: true,
     matchBrackets: true,
-    styleActiveLine: !WURFL || !WURFL.is_mobile,
+    styleActiveLine: true,
     showTrailingSpace: true,
     indentWithTabs: false,
     indentUnit: 2,

--- a/web/run.html
+++ b/web/run.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>CodeWorld</title>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,Number.isFinite,Number.isInteger,console,console.log,document.head,performance.now"></script>
   </head>
 
   <body></body>


### PR DESCRIPTION
The polyfills are not required anymore.

I also removed the device detection. This means that the active line in the editor will always be highlighted now, even when on a mobile device. I would also assume that our recommendation is to use a desktop computer anyway.

Closes #32