### PR TITLE
Fix backslash being interpreted as escape character in code

### DIFF
--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -366,7 +366,7 @@ picture = ...
   }
 
   if(window.preloadCode && window.buildMode === 'haskell'){
-    const codeToLoad = new DOMParser().parseFromString(window.preloadCode, 'text/html').documentElement.textContent;
+    const codeToLoad = new DOMParser().parseFromString(String.raw`${window.preloadCode}`, 'text/html').documentElement.textContent;
     setCode(codeToLoad);
   };
 }


### PR DESCRIPTION
The problem was discussed [here](https://git.uni-due.de/fmi/autotool-dev/-/issues/27).