### PR TITLE
Band-aid fix for backticks in Haskell code

### DIFF
--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -501,7 +501,8 @@ serveEditor = public $ \ctx -> do
   msource <- getParam "source"
   modifyResponse $ setContentType "text/html"
   template <- liftIO $ readFile "web/env.html"
-  let content = replace "/*CODE_TO_BE_LOADED_BY_DEFAULT*/" (maybe "" (T.unpack . T.decodeUtf8) msource) template 
+  let code = maybe "" (T.unpack . T.decodeUtf8) msource
+  let content = replace "/*CODE_TO_BE_LOADED_BY_DEFAULT*/" (replace "`" "\\`" code) template 
   writeBS $ T.encodeUtf8 $ T.pack content
 
 indentHandler :: CodeWorldHandler


### PR DESCRIPTION
This fixes code with backticks in it not loading #43. Might also fix the injection (hard to say without knowing the actual injection code). 

I still might want to change the whole preloading process to work on escaped/encoded code. But I need some time for this (that I don't have currently).