### PR TITLE
Fix escaping issues

### DIFF
--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -497,8 +497,13 @@ runMessageHandler = public $ \ctx -> do
   serveFile (buildRootDir mode </> resultFile programId)
 
 escapeCode :: String -> String
-escapeCode input = foldr (\r acc -> replace r ('\\':r) acc) input toBeEscaped
-  where toBeEscaped = ["${","`","\\"]
+escapeCode input = foldr
+  (\r -> replace r ('\\':r))
+  (escapeBackslashes input)
+  toBeEscaped
+  where 
+    escapeBackslashes = replace "\\" "\\\\"
+    toBeEscaped = ["${","`"]
 
 serveEditor :: CodeWorldHandler
 serveEditor = public $ \ctx -> do

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -496,13 +496,17 @@ runMessageHandler = public $ \ctx -> do
   modifyResponse $ setContentType "text/plain"
   serveFile (buildRootDir mode </> resultFile programId)
 
+escapeCode :: String -> String
+escapeCode input = foldr (\r acc -> replace r ('\\':r) acc) input toBeEscaped
+  where toBeEscaped = ["${","`","\\"]
+
 serveEditor :: CodeWorldHandler
 serveEditor = public $ \ctx -> do
   msource <- getParam "source"
   modifyResponse $ setContentType "text/html"
   template <- liftIO $ readFile "web/env.html"
   let code = maybe "" (T.unpack . T.decodeUtf8) msource
-  let content = replace "/*CODE_TO_BE_LOADED_BY_DEFAULT*/" (replace "`" "\\`" code) template 
+  let content = replace "/*CODE_TO_BE_LOADED_BY_DEFAULT*/" (escapeCode code) template 
   writeBS $ T.encodeUtf8 $ T.pack content
 
 indentHandler :: CodeWorldHandler

--- a/web/env.html
+++ b/web/env.html
@@ -38,7 +38,7 @@
       href="mirrored/ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"
     />
     <script>
-      window.preloadCode = String.raw`/*CODE_TO_BE_LOADED_BY_DEFAULT*/`;
+      window.preloadCode = `/*CODE_TO_BE_LOADED_BY_DEFAULT*/`;
     </script>
   </head>
 


### PR DESCRIPTION
Let me explain how this works, so everybody can validate:

The code which should be loaded will end up in a template literal in the source code of the page:
```js
window.preloadCode = `/*CODE_TO_BE_LOADED_BY_DEFAULT*/`;
```
Note that we do not use `String.raw` here, so a `\` in the string is actually interpreted as an escape character.

We need to make sure that the following conditions hold in order to make sure the source code is displayed correctly at the end:
- the code does not include unescaped `\` (`\x -> ...` would be rendered as `x -> ...` otherwise)
- the code does not include unescaped backticks (it would break the template literal otherwise)
- the code does not include unescaped `${` (it would be possible to execute arbitrary JavaScript code otherwise)

The posted source code will arrive at the CodeWorld server and will be escaped before passing it to the client side code.


**TLDR:** escape the code before handing it to the client so that it doesn't break 