### PR TITLE
Allow to post code to CodeWorld runner

### DIFF
--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -132,7 +132,8 @@ site ctx =
           ("errorCheck", errorCheckHandler ctx),
           ("runBaseJS", runBaseHandler ctx),
           ("haskell", serveEditor ctx),
-          ("indent", indentHandler ctx)
+          ("indent", indentHandler ctx),
+          ("run", runHandler ctx)
         ]
    in route routes <|> serveDirectory "web"
 
@@ -251,6 +252,15 @@ indentHandler ctx = do
     handleError (e :: OrmoluException) = do
       modifyResponse $ setResponseCode 500 . setContentType "text/plain"
       writeLBS $ LB.fromStrict $ T.encodeUtf8 $ T.pack (show e)
+
+runHandler :: CodeWorldHandler
+runHandler ctx = do
+  msource <- getParam "source"
+  modifyResponse $ setContentType "text/html"
+  template <- liftIO $ readFile "web/run.html"
+  let code = maybe "" (T.unpack . T.decodeUtf8) msource
+  let content = replace "/*CODE_TO_BE_LOADED_BY_DEFAULT*/" (escapeCode code) template 
+  writeBS $ T.encodeUtf8 $ T.pack content
 
 responseCodeFromCompileStatus :: CompileStatus -> Int
 responseCodeFromCompileStatus CompileSuccess = 200

--- a/web/js/run.js
+++ b/web/js/run.js
@@ -253,27 +253,30 @@ async function init() {
 
   const codeSrc = params['loadSrc'];
 
-  if(codeSrc) {
+  if(codeSrc || window.preloadCode) {
     try {
-      const response = await fetch(codeSrc);
-      const code = await response.text();
-
-      if(response.ok){
-        const data = new FormData();
-        data.append('source', code);
-        data.append('mode', mode);
-        sendHttp('POST', 'compile', data, (request) => {
-          const { status, responseText } = request;
-          if(status < 500) {
-            const parts = responseText.split('\n=======================\n');
-            const program = parts[3];
-            const loadScript = document.createElement('script');
-            loadScript.setAttribute('type', 'text/javascript');
-            loadScript.innerHTML = program;
-            document.body.appendChild(loadScript);
-          }
-        });
+      let code = window.preloadCode;
+      if(!code) {
+        const response = await fetch(codeSrc);
+        code = await response.text();
+        if(!response.ok) {
+          throw new Error("Could not load source code from external location. Response code not OK.");
+        }
       }
+      const data = new FormData();
+      data.append('source', code);
+      data.append('mode', mode);
+      sendHttp('POST', 'compile', data, (request) => {
+        const { status, responseText } = request;
+        if(status < 500) {
+          const parts = responseText.split('\n=======================\n');
+          const program = parts[3];
+          const loadScript = document.createElement('script');
+          loadScript.setAttribute('type', 'text/javascript');
+          loadScript.innerHTML = program;
+          document.body.appendChild(loadScript);
+        }
+      });
     } catch (error) {
       console.error(error);
     }

--- a/web/run.html
+++ b/web/run.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <title>CodeWorld</title>
+    <script>
+      window.preloadCode = `/*CODE_TO_BE_LOADED_BY_DEFAULT*/`;
+    </script>
   </head>
 
   <body></body>


### PR DESCRIPTION
Closes #58.

Code can be posted against the `/run` endpoint, similar to how you can post code to the editor. The only difference is that a build mode must be provided as a query parameter.

For Haskell: `/run?mode=haskell`
For CodeWorld: `/run?mode=codeworld`