### PR TITLE
Optimize Dockerfile + Fix usage of old endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,18 @@ COPY --chown=codeworld base.sh ./
 
 RUN $CODEWORLD_DIR/mirror/get_mirrored
 
+COPY --chown=codeworld codeworld-error-sanitizer/codeworld-error-sanitizer.cabal codeworld-error-sanitizer/codeworld-error-sanitizer.cabal 
+COPY --chown=codeworld codeworld-api/codeworld-api.cabal codeworld-api/codeworld-api.cabal
+COPY --chown=codeworld codeworld-base/codeworld-base.cabal codeworld-base/codeworld-base.cabal
+COPY --chown=codeworld codeworld-available-pkgs/codeworld-available-pkgs.cabal codeworld-available-pkgs/codeworld-available-pkgs.cabal
+
+RUN bash -c "source base.sh && cabal_install --only-dependencies --ghcjs ./codeworld-error-sanitizer ./codeworld-api ./codeworld-base ./codeworld-available-pkgs"
+
+COPY --chown=codeworld codeworld-server/codeworld-server.cabal codeworld-server/codeworld-server.cabal
+COPY --chown=codeworld codeworld-compiler/codeworld-compiler.cabal codeworld-compiler/codeworld-compiler.cabal
+
+RUN bash -c "source base.sh && cabal_install --only-dependencies ./codeworld-server ./codeworld-error-sanitizer ./codeworld-compiler ./codeworld-api"
+
 COPY --chown=codeworld codeworld-error-sanitizer/ codeworld-error-sanitizer/ 
 COPY --chown=codeworld codeworld-api/ codeworld-api/
 COPY --chown=codeworld codeworld-base/ codeworld-base/

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -133,7 +133,9 @@ site ctx =
           ("runBaseJS", runBaseHandler ctx),
           ("haskell", serveEditor ctx),
           ("indent", indentHandler ctx),
-          ("run", runHandler ctx)
+          ("run", runHandler ctx),
+          ("run.html", redirect "/run"),
+          ("env.html", redirect "/")
         ]
    in route routes <|> serveDirectory "web"
 

--- a/web/js/codeworld_shared.js
+++ b/web/js/codeworld_shared.js
@@ -972,7 +972,7 @@ function run(hash, dhash, msg, error, generation) {
 
   if (dhash) {
     // const loc = `run.html?dhash=${dhash}&mode=${window.buildMode}`;
-    const loc = `run.html?mode=${window.buildMode}`;
+    const loc = `run?mode=${window.buildMode}`;
     runner.contentWindow.location.replace(loc);
     if (
       Boolean(navigator.mediaDevices) &&


### PR DESCRIPTION
This Dockerfile change should reduce the build time significantly after its first build. The dependencies basically never change and can (and should) be build in its own stage to enable caching.

This PR also fixes a small bug I encountered. The code used an old endpoint which basically lead to useless and failing hits to the `/compile` endpoint when using the editor. The functionality of the site however was not influenced.