### PR TITLE
Implement previews

### DIFF
--- a/codeworld-server/codeworld-server.cabal
+++ b/codeworld-server/codeworld-server.cabal
@@ -15,7 +15,7 @@ Description:
 Executable codeworld-server
   Hs-source-dirs: src
   Main-is: Main.hs
-  Other-modules: Model, Util
+  Other-modules: Model, Util, Config
 
   Build-depends:
     aeson,
@@ -23,6 +23,7 @@ Executable codeworld-server
     base64-bytestring,
     bytestring,
     codeworld-compiler,
+    containers,
     cryptonite,
     data-default,
     directory,
@@ -45,7 +46,8 @@ Executable codeworld-server
     temporary,
     text,
     unix,
-    vector
+    vector,
+    yaml
 
   Ghc-options: -threaded
                -Wall

--- a/codeworld-server/src/Config.hs
+++ b/codeworld-server/src/Config.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Config
+  ( Config (..)
+  , PreviewConfig (..)
+  , loadConfig
+  ) 
+where
+
+import Data.Map (Map, fromAscList)
+import Data.Text (Text)
+import Data.Yaml (FromJSON(..), withObject, (.:?), (.!=), decodeFileEither, prettyPrintParseException)
+import System.Environment (lookupEnv, getExecutablePath)
+import System.FilePath (FilePath, takeDirectory)
+import System.IO (hPutStrLn, stderr)
+
+data Config = Config 
+  { previewConfig :: PreviewConfig
+  } deriving Show
+
+data PreviewConfig = PreviewConfig
+  { enabledByDefault :: Bool
+  , defaultHoleValues :: Map Text Text
+  } deriving Show
+
+defaultConfig :: Config
+defaultConfig = Config
+  { previewConfig = defaultPreviewConfig
+  }
+
+defaultPreviewConfig :: PreviewConfig
+defaultPreviewConfig = PreviewConfig
+  { enabledByDefault = False
+  , defaultHoleValues = fromAscList []
+  }
+
+instance FromJSON Config where
+  parseJSON = withObject "Config" $ \v -> Config
+    <$> v .:? "preview" .!= defaultPreviewConfig
+
+instance FromJSON PreviewConfig where
+  parseJSON = withObject "PreviewConfig" $ \v -> PreviewConfig
+    <$> v .:? "enabledByDefault" .!= False
+    <*> v .:? "defaultHoleValues" .!= fromAscList []
+
+determineConfigPath :: IO FilePath
+determineConfigPath = do
+  configPathFromEnv <- lookupEnv "CONFIG_PATH" :: IO (Maybe FilePath)
+  case configPathFromEnv of
+    Just path -> pure path
+    Nothing -> do
+      exePath <- getExecutablePath
+      pure (takeDirectory exePath ++ "/config.yaml")
+
+
+loadConfig :: IO Config
+loadConfig = do
+  configPath <- determineConfigPath
+  parseResult <- decodeFileEither configPath
+  case parseResult of
+    Left err -> do
+      hPutStrLn stderr ("Warning: Failed to load CodeWorld config from " ++ configPath ++ ". Resuming with default config. ")
+      hPutStrLn stderr $ prettyPrintParseException err
+      pure defaultConfig
+    Right cfg -> do 
+      putStrLn "Successfully loaded CodeWorld config."
+      print cfg
+      pure cfg

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -32,8 +32,8 @@ import Control.Applicative
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MSem (MSem)
 import qualified Control.Concurrent.MSem as MSem
-import Control.Exception (bracket_)
-import Control.Exception.Lifted (catch)
+import Control.Exception (SomeException, bracket_, catch)
+import qualified Control.Exception.Lifted as CE (catch)
 import Control.Monad
 import Control.Monad.Trans
 import Data.Aeson
@@ -145,6 +145,16 @@ site ctx =
         ]
    in route routes <|> serveDirectory "web"
 
+assert :: Bool -> IO ()
+assert p =
+  if p
+    then pure ()
+    else fail "assert failed"
+
+tryOr :: a -> IO a -> IO a
+tryOr fallback action = 
+  catch action (\(_ :: SomeException) -> pure fallback)
+
 -- A DirectoryConfig that sets the cache-control header to avoid errors when new
 -- changes are made to JavaScript.
 dirConfig :: DirectoryConfig Snap
@@ -182,6 +192,17 @@ runCompile ctx programId mode source = withSystemTempDirectory "codeworld" $ \te
         pure (status, Left $ T.pack content)
       _ -> pure (status, Left "Something went wrong")
 
+replaceUndefinedWithHole :: Text -> (Int, Text)
+replaceUndefinedWithHole txt = (length matches, replace matches 0 txt)
+  where
+    undefinedRegex = "\\bundefined\\b" :: Text
+    matches = getAllMatches (txt =~ undefinedRegex) :: [(Int,Int)]
+
+    replace [] _ t = t
+    replace ((targetIndex,_):xs) cursor t = 
+      let (before, rest) = T.splitAt (targetIndex - cursor) t
+       in before <> "_" <> replace xs (targetIndex + 9) (T.drop 9 rest)
+
 replaceHolesWithDefaultValue :: [(Int,Int,Text)] -> M.Map Text Text -> Text -> Maybe Text
 replaceHolesWithDefaultValue holes defaults input = T.unlines <$> replaceHolesInLines lines
   where 
@@ -197,7 +218,14 @@ replaceHolesWithDefaultValue holes defaults input = T.unlines <$> replaceHolesIn
         Just defaultValue -> do
           newRest <- replaceHolesInLine xs (c + 1) (T.drop 1 rest)
           pure $ before <> "(" <> defaultValue <> ")" <> newRest
-  
+
+extractHolesFromErrorText :: Text -> [(Int,Int,Text)]
+extractHolesFromErrorText error =
+  let errorSplit = T.splitOn "\n\n" error
+      regex = "^program\\.hs:([[:digit:]]+):([[:digit:]]+): error:[[:cntrl:]] +[^F]+Found hole: _ :: ([[:print:]]+)[[:cntrl:]]" :: Text
+      matches = concatMap (\block -> block =~ regex :: [[Text]]) errorSplit
+      textToInt = read . T.unpack
+   in mapMaybe (\input -> case input of { [_,line,col,ty] -> Just (textToInt line, textToInt col, ty); _ -> Nothing } ) matches
 
 compileHandler :: CodeWorldHandler
 compileHandler ctx = do
@@ -215,30 +243,30 @@ compileHandler ctx = do
         Just "false" -> False
         _ -> enabledByDefault previewConf
 
-  (compileStatus, result) <- do 
-    (status, res) <- liftIO $ runCompile ctx programId mode source
-    if not previewsEnabled || status /= CompileSuccess
-      then pure (status, res)
-      else do 
-        let sourceWithHoles = T.replace "undefined" "_" source
-        (status',res') <- liftIO $ runCompile ctx programId mode sourceWithHoles
-        case res' of
-          Right _ -> pure (status', res')
-          Left error -> do
-            let errorSplit = T.splitOn "\n\n" error
-                regex = "^program\\.hs:([[:digit:]]+):([[:digit:]]+): error:[[:cntrl:]] +[^F]+Found hole: _ :: ([[:print:]]+)[[:cntrl:]]" :: Text
-                matches = concatMap (\block -> block =~ regex :: [[Text]]) errorSplit
-                textToInt = read . T.unpack
-                holes = mapMaybe (\input -> case input of { [_,line,col,ty] -> Just (textToInt line, textToInt col, ty); _ -> Nothing } ) matches
-                replacementMap = defaultHoleValues previewConf
+  (compileStatus, result) <- liftIO $ do 
+    (originalStatus, originalResult) <- runCompile ctx programId mode source
 
-            case replaceHolesWithDefaultValue holes replacementMap sourceWithHoles of
-              Nothing -> pure (status, res)
-              Just withDefaultValues -> do
-                (status'',res'') <- liftIO $ runCompile ctx programId mode withDefaultValues
-                case status'' of
-                  CompileSuccess -> pure (status'', res'')
-                  _ -> pure (status, res)
+    tryOr (originalStatus, originalResult) $ do
+      assert previewsEnabled
+      assert $ originalStatus == CompileSuccess
+      
+      let (replaceCount, sourceWithHolePlaceholders) = replaceUndefinedWithHole source
+      assert $ replaceCount > 0
+
+      (_,Left error) <- runCompile ctx programId mode sourceWithHolePlaceholders
+
+      let holes = extractHolesFromErrorText error
+
+      assert $ replaceCount == length holes
+
+      let replacementMap = defaultHoleValues previewConf
+          Just withDefaultValues = replaceHolesWithDefaultValue holes replacementMap sourceWithHolePlaceholders
+
+      (status', res') <- runCompile ctx programId mode withDefaultValues
+
+      assert $ status' == CompileSuccess
+
+      pure (status', res')
 
   let responseBody = T.intercalate "\n=======================\n" $ case result of 
           Right (content, target) -> [id,did,content,target]
@@ -303,7 +331,7 @@ indentHandler :: CodeWorldHandler
 indentHandler ctx = do
   mode <- getBuildMode
   Just source <- getParam "source"
-  reformat source `catch` handleError
+  reformat source `CE.catch` handleError
   where
     reformat source = do
       result <- ormolu defaultConfig "program.hs" (T.unpack (T.decodeUtf8 source))

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -216,7 +216,7 @@ replaceHolesWithDefaultValue holes defaults input = T.unlines <$> replaceHolesIn
        in case M.lookup ty defaults of
         Nothing -> Nothing
         Just defaultValue -> do
-          newRest <- replaceHolesInLine xs (c + 1) (T.drop 1 rest)
+          newRest <- replaceHolesInLine xs (c + 1) (T.drop 9 rest)
           pure $ before <> "(" <> defaultValue <> ")" <> newRest
 
 extractHolesFromErrorText :: Text -> [(Int,Int,Text)]
@@ -256,11 +256,8 @@ compileHandler ctx = do
       (_,Left error) <- runCompile ctx programId mode sourceWithHolePlaceholders
 
       let holes = extractHolesFromErrorText error
-
-      assert $ replaceCount == length holes
-
-      let replacementMap = defaultHoleValues previewConf
-          Just withDefaultValues = replaceHolesWithDefaultValue holes replacementMap sourceWithHolePlaceholders
+          replacementMap = defaultHoleValues previewConf
+          Just withDefaultValues = replaceHolesWithDefaultValue holes replacementMap source
 
       (status', res') <- runCompile ctx programId mode withDefaultValues
 

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -196,7 +196,7 @@ replaceHolesWithDefaultValue holes defaults input = T.unlines <$> replaceHolesIn
         Nothing -> Nothing
         Just defaultValue -> do
           newRest <- replaceHolesInLine xs (c + 1) (T.drop 1 rest)
-          pure $ before <> defaultValue <> newRest
+          pure $ before <> "(" <> defaultValue <> ")" <> newRest
   
 
 compileHandler :: CodeWorldHandler
@@ -226,12 +226,11 @@ compileHandler ctx = do
           Right _ -> pure (status', res')
           Left error -> do
             let errorSplit = T.splitOn "\n\n" error
-                regex = "^program\\.hs:([[:digit:]]+):([[:digit:]]+): error:[[:cntrl:]] +[^F]+Found hole: _ :: ([[:alnum:]]+)" :: Text
+                regex = "^program\\.hs:([[:digit:]]+):([[:digit:]]+): error:[[:cntrl:]] +[^F]+Found hole: _ :: ([[:print:]]+)[[:cntrl:]]" :: Text
                 matches = concatMap (\block -> block =~ regex :: [[Text]]) errorSplit
                 textToInt = read . T.unpack
                 holes = mapMaybe (\input -> case input of { [_,line,col,ty] -> Just (textToInt line, textToInt col, ty); _ -> Nothing } ) matches
                 replacementMap = defaultHoleValues previewConf
-                
 
             case replaceHolesWithDefaultValue holes replacementMap sourceWithHoles of
               Nothing -> pure (status, res)

--- a/codeworld-server/src/Main.hs
+++ b/codeworld-server/src/Main.hs
@@ -27,6 +27,7 @@ module Main where
 
 import CodeWorld.Compile
 import CodeWorld.Compile.Base
+import Config
 import Control.Applicative
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MSem (MSem)
@@ -42,6 +43,7 @@ import qualified Data.ByteString.Lazy as LB
 import Data.Char (isSpace)
 import Data.List
 import Data.List.Extra (replace)
+import qualified Data.Map as M
 import Data.Maybe
 import Data.Monoid
 import Data.Text (Text)
@@ -64,6 +66,7 @@ import System.IO.Temp
 import System.Environment (lookupEnv)
 import Util
 import Text.Read (readMaybe)
+import Text.Regex.TDFA
 
 maxSimultaneousCompiles :: Int
 maxSimultaneousCompiles = 4
@@ -74,24 +77,27 @@ maxSimultaneousErrorChecks = 2
 data Context = Context
   { compileSem :: MSem Int,
     errorSem :: MSem Int,
-    baseSem :: MSem Int
+    baseSem :: MSem Int,
+    config :: Config
   }
 
 main :: IO ()
 main = do
-  ctx <- makeContext
+  cfg <- loadConfig
+  ctx <- makeContext cfg
   port <- maybe Nothing readMaybe <$> lookupEnv "PORT" :: IO (Maybe Int)
   cfg <- S.commandLineConfig ((maybe id (\p -> S.setPort p) port) S.defaultConfig)
   forkIO $ baseVersion >>= buildBaseIfNeeded ctx >> return ()
   httpServe cfg $ (processBody >> site ctx) <|> site ctx
 
-makeContext :: IO Context
-makeContext = do
+makeContext :: Config -> IO Context
+makeContext cfg = do
   ctx <-
     Context
       <$> MSem.new maxSimultaneousCompiles
       <*> MSem.new maxSimultaneousErrorChecks
       <*> MSem.new 1
+      <*> pure cfg
   return ctx
 
 -- | A CodeWorld Snap API action
@@ -152,39 +158,92 @@ withProgramLock (BuildMode mode) (ProgramId hash) action = do
   let tmpFile = tmpDir </> "codeworld" <.> T.unpack hash <.> mode
   withFileLock tmpFile Exclusive (const action)
 
-compileHandler :: CodeWorldHandler
-compileHandler ctx = do
-  mode <- getBuildMode
-  Just source <- getParam "source"
-  let programId = sourceToProgramId source
-      deployId = sourceToDeployId source
-      id = unProgramId programId
-      did = unDeployId deployId
 
-  (compileStatus, responseBody) <- liftIO $ withSystemTempDirectory "codeworld" $ \tempDir -> do
+runCompile :: Context -> ProgramId -> BuildMode -> Text -> IO (CompileStatus, Either Text (Text,Text))
+runCompile ctx programId mode source = withSystemTempDirectory "codeworld" $ \tempDir -> do
     let sourceDir = tempDir </> "source"
         buildDir = tempDir </> "build"
     createDirectoryIfMissing True sourceDir
     createDirectoryIfMissing True buildDir
 
     status <- withProgramLock mode programId $ do
-      B.writeFile (sourceDir </> sourceFile programId) source
+      T.writeFile (sourceDir </> sourceFile programId) source
       compileIfNeeded ctx tempDir mode programId
 
     hasResultFile <- doesFileExist (buildDir </> resultFile programId)
 
-    resBody <- case status of
+    case status of
       CompileSuccess | hasResultFile -> do
         content <- readFile (buildDir </> resultFile programId)
         target <- readFile (buildDir </> targetFile programId)
-        pure $ T.intercalate "\n=======================\n" [id,did,T.pack content,T.pack target]
+        pure (status, Right (T.pack content,T.pack target))
       _ | hasResultFile -> do
         content <- readFile (buildDir </> resultFile programId)
-        pure $ T.intercalate "\n=======================\n" [id,did,T.pack content]
-      _ -> pure "Something went wrong"
-      
-    pure (status, resBody)
-    
+        pure (status, Left $ T.pack content)
+      _ -> pure (status, Left "Something went wrong")
+
+replaceHolesWithDefaultValue :: [(Int,Int,Text)] -> M.Map Text Text -> Text -> Maybe Text
+replaceHolesWithDefaultValue holes defaults input = T.unlines <$> replaceHolesInLines lines
+  where 
+    lines = zip [1 :: Int ..] $ T.lines input
+
+    replaceHolesInLines lines = traverse (\(num,line) -> replaceHolesInLine (filter (\(r,_,_) -> r == num) holes) 1 line) lines
+
+    replaceHolesInLine [] _ line = Just line
+    replaceHolesInLine ((_,c,ty):xs) cursor line = 
+      let (before,rest) = T.splitAt (c - cursor) line
+       in case M.lookup ty defaults of
+        Nothing -> Nothing
+        Just defaultValue -> do
+          newRest <- replaceHolesInLine xs (c + 1) (T.drop 1 rest)
+          pure $ before <> defaultValue <> newRest
+  
+
+compileHandler :: CodeWorldHandler
+compileHandler ctx = do
+  mode <- getBuildMode
+  let previewConf = previewConfig $ config ctx
+  Just source <- (T.decodeUtf8 <$>) <$> getParam "source"
+  mPreview <- getParam "enablePreview"
+  let programId = sourceToProgramId $ T.encodeUtf8 source
+      id = unProgramId programId
+      did = "deploy_id"
+      previewsEnabled = case mPreview of
+        Just "True" -> True
+        Just "true" -> True
+        Just "False" -> False
+        Just "false" -> False
+        _ -> enabledByDefault previewConf
+
+  (compileStatus, result) <- do 
+    (status, res) <- liftIO $ runCompile ctx programId mode source
+    if not previewsEnabled || status /= CompileSuccess
+      then pure (status, res)
+      else do 
+        let sourceWithHoles = T.replace "undefined" "_" source
+        (status',res') <- liftIO $ runCompile ctx programId mode sourceWithHoles
+        case res' of
+          Right _ -> pure (status', res')
+          Left error -> do
+            let errorSplit = T.splitOn "\n\n" error
+                regex = "^program\\.hs:([[:digit:]]+):([[:digit:]]+): error:[[:cntrl:]] +[^F]+Found hole: _ :: ([[:alnum:]]+)" :: Text
+                matches = concatMap (\block -> block =~ regex :: [[Text]]) errorSplit
+                textToInt = read . T.unpack
+                holes = mapMaybe (\input -> case input of { [_,line,col,ty] -> Just (textToInt line, textToInt col, ty); _ -> Nothing } ) matches
+                replacementMap = defaultHoleValues previewConf
+                
+
+            case replaceHolesWithDefaultValue holes replacementMap sourceWithHoles of
+              Nothing -> pure (status, res)
+              Just withDefaultValues -> do
+                (status'',res'') <- liftIO $ runCompile ctx programId mode withDefaultValues
+                case status'' of
+                  CompileSuccess -> pure (status'', res'')
+                  _ -> pure (status, res)
+
+  let responseBody = T.intercalate "\n=======================\n" $ case result of 
+          Right (content, target) -> [id,did,content,target]
+          Left errorMessage -> [id,did,errorMessage]    
 
   modifyResponse $ setResponseCode (responseCodeFromCompileStatus compileStatus)
   modifyResponse $ setContentType "text/plain"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+preview:
+  enabledByDefault: false
+  defaultHoleValues:
+    "Double -> Picture": "const blank"
+    "Double": "0"
+    "Color": "black"
+    "Picture": "blank"
+    "TextStyle": "Plain"
+    "Font": "Monospace"
+    "Text": "\"\""
+    "Point": "(0,0)"
+    "Vector": "(0,0)"

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ preview:
     "Picture": "blank"
     "TextStyle": "Plain"
     "Font": "Monospace"
-    "Text": "\"\""
+    "Text": "mempty"
+    "Data.Text.Internal.Text": "mempty"
     "Point": "(0,0)"
     "Vector": "(0,0)"

--- a/config/keter.yaml
+++ b/config/keter.yaml
@@ -11,6 +11,7 @@ stanzas:
       LC_ALL: "C.UTF-8"
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/codeworld/build/bin"
       EXTENSIONS_CONFIG_PATH: "/opt/codeworld/extensions.yaml"
+      CONFIG_PATH: "/opt/codeworld/config.yaml"
 
     hosts:
       - localhost

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,3 +3,4 @@ haskell:
   - LambdaCase
   - NoTemplateHaskell
   - TupleSections
+  - OverloadedStrings

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,4 +3,3 @@ haskell:
   - LambdaCase
   - NoTemplateHaskell
   - TupleSections
-  - OverloadedStrings

--- a/publish.sh
+++ b/publish.sh
@@ -20,7 +20,7 @@ fi
 
 cp codeworld.tar codeworld-tmp.tar
 
-tar -rf codeworld-tmp.tar config/keter.yaml extensions.yaml
+tar -rf codeworld-tmp.tar config/keter.yaml extensions.yaml config.yaml
 
 gzip codeworld-tmp.tar
 

--- a/run.sh
+++ b/run.sh
@@ -28,5 +28,6 @@ fuser -k -n tcp "${PORT}"
 
 mkdir -p log
 
+export CONFIG_PATH=$(pwd)/config.yaml
 export EXTENSIONS_CONFIG_PATH=$(pwd)/extensions.yaml
 run . ./build/bin/codeworld-server -p $PORT --no-access-log

--- a/web/js/codeworld.js
+++ b/web/js/codeworld.js
@@ -985,6 +985,10 @@ function compile() {
   data.append('source', src);
   data.append('mode', window.buildMode);
 
+  const searchParams = new URLSearchParams(window.location.search);
+
+  if(searchParams.has("enablePreview")) data.append("enablePreview", searchParams.get("enablePreview"));
+
   let compileFinished = false;
 
   window.cancelCompile = () => {

--- a/web/js/run.js
+++ b/web/js/run.js
@@ -266,6 +266,11 @@ async function init() {
       const data = new FormData();
       data.append('source', code);
       data.append('mode', mode);
+
+      const enablePreview = params['enablePreview'];
+
+      if(enablePreview) data.append('enablePreview',enablePreview);
+      
       sendHttp('POST', 'compile', data, (request) => {
         const { status, responseText } = request;
         if(status < 500) {


### PR DESCRIPTION
This pull request implements previews that allow us to show preview images of incomplete programs.

Example:
```haskell
import CodeWorld

{-| Draw something -}
main :: IO ()
main = drawingOf (translated 5 undefined (circle 3) & undefined)
```
will produce this image:
<img width="974" height="918" alt="image" src="https://github.com/user-attachments/assets/9f1165de-59c5-4e95-b099-094b734fb4f2" />

The feature can be enabled per-request by adding a `enablePreview` field to the `/compile` request that has value `true`. It can also be enabled by default via a config setting. The field value in the request will then override the default.

The config path can be set via the `CONFIG_PATH` environment variable. The content of the `config.yaml` would then look like this:

```yaml
preview:
  enabledByDefault: false
  defaultHoleValues:
    Double: "0"
    Color: "black"
    Picture: "blank"
```

(My further goal is to replace the `extensions.yaml` config file by a field in this new consolidated config.)

A few questions left:
- Should this also work in the non-Haskell mode? (It currently does not)
- Should the user be able to configure this itself in the editor?