### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     # need to install older cabal/ghc versions from ppa repository
 
     - name: Install recent cabal/ghc
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         versions:
           - ghc: '8.6.5'
-            cabal: '2.4.1.0'
+            cabal: '3.14.2.0'
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     # need to install older cabal/ghc versions from ppa repository
 
     - name: Install recent cabal/ghc
-      uses: haskell-actions/setup@v2
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     # need to install older cabal/ghc versions from ppa repository
 
-    - name: Install recent cabal/ghc
+    - name: Install production GHC and recent cabal
       uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         versions:
           - ghc: '8.6.5'
-            cabal: '3.4'
+            cabal: '2.4.1.0'
     steps:
     - uses: actions/checkout@v6
 
     # need to install older cabal/ghc versions from ppa repository
 
     - name: Install recent cabal/ghc
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
           - ghc: '8.6.5'
             cabal: '3.4'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     # need to install older cabal/ghc versions from ppa repository
 
     - name: Install recent cabal/ghc
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}
@@ -36,7 +36,7 @@ jobs:
 
     - name: Cache cabal global package db
       id:   cabal-global
-      uses: actions/cache@v2
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cabal
@@ -44,7 +44,7 @@ jobs:
 
     - name: Cache cabal work
       id:   cabal-local
-      uses: actions/cache@v2
+      uses: actions/cache@v5
       with:
         path: |
           dist-newstyle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         cabal-version: ${{ matrix.versions.cabal }}
 
     # declare/restore cached things
-    # caching doesn't work for scheduled runs yet
-    # https://github.com/actions/cache/issues/63
 
     - name: Cache cabal global package db
       id:   cabal-global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         cabal build all --dependencies-only --enable-tests --disable-optimization
     - name: Build
       run: |
-        cabal build all --enable-tests --disable-optimization 2>&1 | tee build.log
+        cabal build all --enable-tests --disable-optimization
     # - name: Test # needs GHCJS
     #   run: |
     #     cabal test all --disable-optimization

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: */*.cabal
+
+source-repository-package
+    type: git
+    location: https://github.com/fmidue/ghcjs-base-stub.git
+    tag: e19317673d68c2be874fca4661d1ce16b2dc20a1
+
+with-compiler: ghc-8.6.5

--- a/codeworld-compiler/test/Main.hs
+++ b/codeworld-compiler/test/Main.hs
@@ -43,7 +43,7 @@ compilerOutput testName =
       ErrorCheck
       ("test/testcases" </> testName </> "source.hs")
       (magicModuleFinder testName dir)
-      Nothing
+      (ExtraExtensions [] [])
       (dir </> "output.txt")
       buildMode
       False


### PR DESCRIPTION
- update deprecated actions
- add `cabal.project` file for this workflow and local development
- do not redirect `cabal` output into a log file (this made the workflow pass, even on compile errors)


the `cabal.project` can be used to compile all relevant code by calling `cabal build all` in the root directory. This requires a local installation of GHC-8.6.5 (e.g. through `ghcup`), the current GHC version used in the deploy script. Newer versions seem to always fail to resolve dependencies, though this could be updated if we ever want to start migrating to newer versions as discussed in #48. 
