### PR TITLE
Show alert on runtime error in CodeWorld runner

### DIFF
--- a/web/js/run.js
+++ b/web/js/run.js
@@ -193,7 +193,7 @@ function start() {
       str = str.replace(/%s/, args[i]);
     }
     addMessage('error', str);
-    if(window.self === window.top && !window.didShowError) {
+    if (window.self === window.top && !window.didShowError) {
       window.didShowError = true;
       const sanitizedMessage = new DOMParser().parseFromString(str, 'text/html').documentElement.textContent;
       sweetAlert({

--- a/web/js/run.js
+++ b/web/js/run.js
@@ -195,11 +195,11 @@ function start() {
     addMessage('error', str);
     if(window.self === window.top && !window.didShowError) {
       window.didShowError = true;
-      const sanitizedMessage = new DOMParser().parseFromString(str, "text/html").documentElement.textContent;
+      const sanitizedMessage = new DOMParser().parseFromString(str, 'text/html').documentElement.textContent;
       sweetAlert({
         title: 'A runtime error occurred in your program.',
         html: `<pre style="text-align: left;">${sanitizedMessage}</pre>`,
-        width: "fit-content",
+        width: 'fit-content',
         type: 'error',
         showConfirmButton: false,
         showCancelButton: false,

--- a/web/js/run.js
+++ b/web/js/run.js
@@ -29,6 +29,7 @@ import * as Alert from './utils/alert.js';
 // or at startup when the compile errors were just printed anyway.
 window.programStartTime = Date.now();
 window.hasObservableOutput = false;
+window.didShowError = false;
 
 window.addEventListener('message', (event) => {
   if (!event.data.type) return;
@@ -192,6 +193,27 @@ function start() {
       str = str.replace(/%s/, args[i]);
     }
     addMessage('error', str);
+    if(window.self === window.top && !window.didShowError) {
+      window.didShowError = true;
+      const sanitizedMessage = new DOMParser().parseFromString(str, "text/html").documentElement.textContent;
+      sweetAlert({
+        title: 'A runtime error occurred in your program.',
+        html: `<pre style="text-align: left;">${sanitizedMessage}</pre>`,
+        width: "fit-content",
+        type: 'error',
+        showConfirmButton: true,
+        confirmButtonText: "Open in CodeWorld Editor",
+        showCancelButton: false,
+        showCloseButton: false,
+        allowOutsideClick: false,
+        allowEscapeKey: false,
+        allowEnterKey: false,
+      }).then(() => {
+        const searchParams = new URLSearchParams(window.location.search);
+        const mode = searchParams.get('mode') || 'codeworld';
+        window.location.href = `/${mode === 'codeworld' ? '' : mode}${window.location.hash}`;
+      });
+    }
   };
   window.h$base_stdout_fd.write = window.h$base_writeStdout;
   window.h$base_stderr_fd.write = window.h$base_writeStderr;

--- a/web/js/run.js
+++ b/web/js/run.js
@@ -201,17 +201,12 @@ function start() {
         html: `<pre style="text-align: left;">${sanitizedMessage}</pre>`,
         width: "fit-content",
         type: 'error',
-        showConfirmButton: true,
-        confirmButtonText: "Open in CodeWorld Editor",
+        showConfirmButton: false,
         showCancelButton: false,
         showCloseButton: false,
         allowOutsideClick: false,
         allowEscapeKey: false,
         allowEnterKey: false,
-      }).then(() => {
-        const searchParams = new URLSearchParams(window.location.search);
-        const mode = searchParams.get('mode') || 'codeworld';
-        window.location.href = `/${mode === 'codeworld' ? '' : mode}${window.location.hash}`;
       });
     }
   };


### PR DESCRIPTION
The CodeWorld runner now shows the **first** runtime error reported. This alert is only shown when the runner is not embedded on another page (i.e. it does not show the error twice on the editor page).

There is also a button presented to the user that allows it to open the code in the editor.